### PR TITLE
Update ERC721AX.sol

### DIFF
--- a/src/ERC721AX.sol
+++ b/src/ERC721AX.sol
@@ -85,7 +85,7 @@ abstract contract ERC721AX {
         uint256 tokenId
     ) public {
         unchecked {
-            TokenData storage tokenData = _tokenDataOf(tokenId);
+            TokenData memory tokenData = _tokenDataOf(tokenId);
 
             if (tokenData.owner != from) revert TransferFromIncorrectOwner();
 
@@ -210,7 +210,7 @@ abstract contract ERC721AX {
         return startingIndex <= tokenId && tokenId < _currentIndex;
     }
 
-    function _tokenDataOf(uint256 tokenId) internal view returns (TokenData storage tokenData) {
+    function _tokenDataOf(uint256 tokenId) internal view returns (TokenData memory tokenData) {
         unchecked {
             if (!_exists(tokenId)) revert NonexistentToken();
 


### PR DESCRIPTION
Returning `tokenData` as storage causes the following issue:

After modifying `currSlot.nextTokenDataSet` to `true`, lines 110-120 will not be executed, because `tokenData` and `currSlot` points to the same storage slot.

To reproduce:
- Mint "A" 10 tokens, mint "B" 10 tokens.
- Transfer token 1 from "A" to "B".
- Tranferring token 2 from "A" to "B" reverts. 